### PR TITLE
add google analytics

### DIFF
--- a/layout/_partial/google_analytics.ejs
+++ b/layout/_partial/google_analytics.ejs
@@ -1,0 +1,14 @@
+<% if (theme.google_analytics){ %>
+<!-- Google Analytics -->
+<script type="text/javascript">
+(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+ga('create', '<%= theme.google_analytics %>', 'auto');
+ga('send', 'pageview');
+
+</script>
+<!-- End Google Analytics -->
+<% } %>

--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -6,5 +6,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
   <link rel="shortcut icon" href="<%- url_for(theme.favicon) %>">
   <%- css('css/app') %>
+  <%- partial('google_analytics') %>
   <!-- <link rel='stylesheet' href='http://fonts.useso.com/css?family=Source+Code+Pro'> -->
 </head>


### PR DESCRIPTION
Add a little snippet on each page head to include google analytics tracking code when the variable google_analytics on theme config file  is defined.

example: juandavidvega.es
